### PR TITLE
Little fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,26 @@ bin
 *.dll
 
 _*
+
+# VS Code
+/.vscode/
+
+# Compile Commands
+/.cache/
+/compile_commands.json
+
+# Compile Flags
+/compile_flags.txt
+
+# CMake
+/CMakeLists.txt
+/cmake-build-debug/
+/cmake-build-release/
+
+# JetBrains IDEs
+/.idea/
+
+# Visual Studio / Rider
+/vsxmake*/
+/.vs/
+/*/.vs/

--- a/include/core/library.h
+++ b/include/core/library.h
@@ -2,6 +2,8 @@
 #define LIBRARY_H
 
 #if defined(_WIN32)
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 typedef HMODULE DLL;
 #else

--- a/src/core/library.c
+++ b/src/core/library.c
@@ -1,6 +1,8 @@
 #include <core/library.h>
 
 #if defined(_WIN32)
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 DLL load_library(const char* path) { return LoadLibraryA(path); }


### PR DESCRIPTION
NOMINMAX and WIN32_LEAN_AND_MEAN macros added in files that include windows.h so that it doesn't include unnecessary files, and doesn't define its own min() and max() macros to avoid conflicts.

.gitignore file now ignores files from other xmake generators.